### PR TITLE
Sre 2645 added more loging

### DIFF
--- a/mongodb_consistent_backup/Oplog/Resolver/Resolver.py
+++ b/mongodb_consistent_backup/Oplog/Resolver/Resolver.py
@@ -148,5 +148,7 @@ class Resolver(Task):
             self.stopped = True
 
         for shard in self.resolver_state:
+            logging.info("Getting shard oplog state %s" % (shard))
             self.resolver_summary[shard] = self.resolver_state[shard].get()
+        logging.info("Returning self.resolver_summary")
         return self.resolver_summary

--- a/mongodb_consistent_backup/Oplog/Tailer/TailThread.py
+++ b/mongodb_consistent_backup/Oplog/Tailer/TailThread.py
@@ -89,7 +89,7 @@ class TailThread(Process):
 
     def connect(self):
         if not self.db:
-            self.db = DB(self.uri, self.config, True, 'secondary', True)
+            self.db = DB(self.uri, self.config, False, 'secondary', True)
         return self.db.connection()
 
     def run(self):

--- a/mongodb_consistent_backup/Oplog/Tailer/TailThread.py
+++ b/mongodb_consistent_backup/Oplog/Tailer/TailThread.py
@@ -169,6 +169,7 @@ class TailThread(Process):
             self.stopped = True
             self.state.set('running', False)
             self.timer.stop(self.timer_name)
+            logging.info("Thread is stopped and marked as stopped %s" % self.uri)
 
         if self.exit_code == 0:
             log_msg_extra = "%i oplog changes" % self.count

--- a/mongodb_consistent_backup/Oplog/Tailer/Tailer.py
+++ b/mongodb_consistent_backup/Oplog/Tailer/Tailer.py
@@ -102,8 +102,8 @@ class Tailer(Task):
                     logging.warning("Could not get current optime from PRIMARY! Using now as a stop time")
                     timestamp = Timestamp(int(time()), 0)
 
-                # wait for replication to get in sync
-                while state.get('last_ts') and state.get('last_ts') < timestamp:
+                # wait for replication to get in sync making sure cursor has not been stopped in a race condition
+                while state.get('last_ts') and state.get('last_ts') < timestamp and not self.shards[shard].stopped:
                     logging.info('Waiting for %s tailer to reach ts: %s, currrent: %s' % (uri, timestamp, state.get('last_ts')))
                     sleep(sleep_secs)
 

--- a/mongodb_consistent_backup/Oplog/Tailer/Tailer.py
+++ b/mongodb_consistent_backup/Oplog/Tailer/Tailer.py
@@ -103,7 +103,7 @@ class Tailer(Task):
                     timestamp = Timestamp(int(time()), 0)
 
                 # wait for replication to get in sync making sure cursor has not been stopped in a race condition
-                while state.get('last_ts') and state.get('last_ts') < timestamp and not self.shards[shard].['thread'].stopped:
+                while state.get('last_ts') and state.get('last_ts') < timestamp and not self.shards[shard]['thread'].stopped:
                     logging.info('Waiting for %s tailer to reach ts: %s, currrent: %s' % (uri, timestamp, state.get('last_ts')))
                     sleep(sleep_secs)
 

--- a/mongodb_consistent_backup/Oplog/Tailer/Tailer.py
+++ b/mongodb_consistent_backup/Oplog/Tailer/Tailer.py
@@ -103,7 +103,7 @@ class Tailer(Task):
                     timestamp = Timestamp(int(time()), 0)
 
                 # wait for replication to get in sync making sure cursor has not been stopped in a race condition
-                while state.get('last_ts') and state.get('last_ts') < timestamp and not self.shards[shard].stopped:
+                while state.get('last_ts') and state.get('last_ts') < timestamp and not self.shards[shard].['thread'].stopped:
                     logging.info('Waiting for %s tailer to reach ts: %s, currrent: %s' % (uri, timestamp, state.get('last_ts')))
                     sleep(sleep_secs)
 


### PR DESCRIPTION
1) https://github.com/objectrocket/mongodb_consistent_backup/pull/5/files#diff-65088d69efbeaed14dc17e0374cc6752R92 - changed oplog tailer connection to login to a single server in replica set instead of pool of servers in replica.
2)  https://github.com/objectrocket/mongodb_consistent_backup/pull/5/files#diff-f7f0fc30ff8a9b245c806958c07df179R106 in race condition on several occasions the tailer cursor gets stopped while we are checking in the loop for oplog to reach particular point in time. New check prevents infinite looping.

We ended up not using oplog trailer feature at all on our instances so that code is not working in production. All other changes  are additional logging